### PR TITLE
Update repository URL in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 	"description": "Unofficial API Wrapper for the Blesta billing platform",
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/npm/npm.git"
+		"url": "https://github.com/nodecraft/blesta.js.git"
 	},
 	"main": "blesta.js",
 	"scripts": {


### PR DESCRIPTION
Heya, found this repo from npmjs.com but it's linked to the npm git repo not here. Not sure if an informed design decision or oversight, but thought I'd bug y'all about it anyway :)